### PR TITLE
Use HTTPS for Warrior HQ URL

### DIFF
--- a/warrior-runner.sh
+++ b/warrior-runner.sh
@@ -16,6 +16,6 @@ cd /home/warrior/warrior-code2
 $WARRIOR \
   --projects-dir /home/warrior/projects \
   --data-dir /data/data \
-  --warrior-hq http://warriorhq.archiveteam.org \
+  --warrior-hq https://warriorhq.archiveteam.org \
   --port 8001 \
   --real-shutdown


### PR DESCRIPTION
Since the Warrior HQ API supports HTTPS and it essentially allows for arbitrary code execution (the git URL for each project is defined in the response from Warrior HQ), this connection really ought to go over HTTPS to prevent someone from using a man-in-the-middle attack to take over a warrior instance.

Since the Docker image is currently based on Ubuntu 18.04, there should be no compatibility issues with this change.